### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ django-fluent-dashboard
 =======================
 
 The ``fluent_dashboard`` module offers a custom admin dashboard, built on top of
-django-admin-tools_ (`docs <http://django-admin-tools.readthedocs.org/>`_).
+django-admin-tools_ (`docs <https://django-admin-tools.readthedocs.io/>`_).
 
 The django-admin-tools_ package provides a default mechanism to replace the standard Django
 admin homepage with a widget based dashboard. The ``fluent_dashboard`` module extends this,
@@ -14,7 +14,7 @@ by providing additional widgets (called "modules") such as:
 * a "return to site" link.
 * an optional "cache statistics" module.
 
-Documentation can be found at: http://django-fluent-dashboard.readthedocs.org/
+Documentation can be found at: https://django-fluent-dashboard.readthedocs.io/
 
 Screenshot
 ==========
@@ -194,7 +194,7 @@ please let us know as well because we will look into it.
 Pull requests are welcome too. :-)
 
 
-.. _documentation: http://django-fluent-dashboard.readthedocs.org/
+.. _documentation: https://django-fluent-dashboard.readthedocs.io/
 .. _dashboardmods: https://github.com/callowayproject/dashboardmods
 .. _django-admin-tools: https://github.com/django-admin-tools/django-admin-tools
 .. _django-admin-tools-stats: https://github.com/Star2Billing/django-admin-tools-stats

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -63,4 +63,4 @@ which are suitable for overwriting them:
 * :class:`~fluent_dashboard.modules.CacheStatusGroup`: the statistics of Memcache and Varnish.
 
 
-.. _django-admin-tools: http://django-admin-tools.readthedocs.org/
+.. _django-admin-tools: https://django-admin-tools.readthedocs.io/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -251,5 +251,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'http://docs.python.org/': None,
     'https://docs.djangoproject.com/en/dev': 'https://docs.djangoproject.com/en/dev/_objects',
-    'http://django-admin-tools.readthedocs.org/en/latest/': None,
+    'https://django-admin-tools.readthedocs.io/en/latest/': None,
 }

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -181,4 +181,4 @@ A dictionary of `modelname`: `ordering` items, to sort the models of CMS applica
 This can be used for example, to display the pages model first, and the files/images models next.
 
 
-.. _django-admin-tools: http://django-admin-tools.readthedocs.org/
+.. _django-admin-tools: https://django-admin-tools.readthedocs.io/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,4 +68,4 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
-.. _django-admin-tools: http://django-admin-tools.readthedocs.org/
+.. _django-admin-tools: https://django-admin-tools.readthedocs.io/

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -47,4 +47,4 @@ Next:
 * The Memcache and Varnish statistics can also be displayed by configuring some :doc:`optional dependencies <optionaldeps>`.
 
 
-.. _django-admin-tools: http://django-admin-tools.readthedocs.org/
+.. _django-admin-tools: https://django-admin-tools.readthedocs.io/


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.