### PR TITLE
 Admin Panel - User Password Change Form ERROR Fix 

### DIFF
--- a/fluent_dashboard/items.py
+++ b/fluent_dashboard/items.py
@@ -114,11 +114,11 @@ class ReturnToSiteItem(items.MenuItem):
 
             # object_id can be string (e.g. a country code as PK).
             if 'id' in resolvermatch.kwargs:
-                object_id = resolvermatch.kwargs['id']  # Django 2.0+   ; for user passwords
+                object_id = resolvermatch.kwargs['id']          # Django 2.0+   ; for user passwords
             elif 'object_id' in resolvermatch.kwargs:
-                object_id = resolvermatch.kwargs['object_id']  # Django 2.0+  ; for others
+                object_id = resolvermatch.kwargs['object_id']   # Django 2.0+  ; for others
             else:
-                object_id = resolvermatch.args[0]
+                object_id = resolvermatch.args[0]               # Brought forward
             return self.get_object_by_natural_key(match.group(1), match.group(2), object_id)
         return None
 

--- a/fluent_dashboard/items.py
+++ b/fluent_dashboard/items.py
@@ -113,11 +113,12 @@ class ReturnToSiteItem(items.MenuItem):
                 return None
 
             # object_id can be string (e.g. a country code as PK).
-            try:
-                object_id = resolvermatch.kwargs['object_id']  # Django 2.0+
-            except KeyError:
+            if 'id' in resolvermatch.kwargs:
+                object_id = resolvermatch.kwargs['id']  # Django 2.0+   ; for user passwords
+            elif 'object_id' in resolvermatch.kwargs:
+                object_id = resolvermatch.kwargs['object_id']  # Django 2.0+  ; for others
+            else:
                 object_id = resolvermatch.args[0]
-
             return self.get_object_by_natural_key(match.group(1), match.group(2), object_id)
         return None
 


### PR DESCRIPTION
`resolvermatch = urls.resolve(request.path_info)`  
urls.resolve returns url_variables as *args, but now shifted to **kwargs, 

In django admin panel, object-change form passes object-id as as `'(<object_id>)'` but on user password change view, this object-id is passed in name of `'(<id>)'`. This causes `error` on going to change password form. this has been handled in this commit.