### PR TITLE
docs: Fix simple typo, overvivew -> overview

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -3,7 +3,7 @@
 Configuration
 =============
 
-A quick overvivew of the available settings:
+A quick overview of the available settings:
 
 .. code-block:: python
 


### PR DESCRIPTION
There is a small typo in docs/configuration.rst.

Should read `overview` rather than `overvivew`.

